### PR TITLE
changes the insulation calculation if an item is currently worn

### DIFF
--- a/Source/OutfittedMod.cs
+++ b/Source/OutfittedMod.cs
@@ -136,8 +136,7 @@ namespace Outfitted
                 // system to solve would be fairly massive, optimizing for dozens of pawns and hundreds of pieces 
                 // of gear simultaneously. Second, many of the stat functions aren't actually linear, and would
                 // have to be made to be linear.
-                if ( pawn.apparel.WornApparel.Contains( apparel ) )
-                    return 1f;
+                var currentlyWorn = pawn.apparel.WornApparel.Contains(apparel);
 
                 var currentRange = pawn.ComfortableTemperatureRange();
                 var candidateRange = currentRange;
@@ -152,15 +151,18 @@ namespace Outfitted
                 // effect of this piece of apparel
                 candidateRange.min += apparelOffset.min;
                 candidateRange.max += apparelOffset.max;
-                foreach (var otherApparel in pawn.apparel.WornApparel)
+                if(!currentlyWorn)
                 {
-                    // effect of taking off any other apparel that is incompatible
-                    if (!ApparelUtility.CanWearTogether(apparel.def, otherApparel.def, pawn.RaceProps.body))
+                    foreach (var otherApparel in pawn.apparel.WornApparel)
                     {
-                        var otherInsulationRange = GetInsulationStats(otherApparel);
+                        // effect of taking off any other apparel that is incompatible
+                        if (!ApparelUtility.CanWearTogether(apparel.def, otherApparel.def, pawn.RaceProps.body))
+                        {
+                            var otherInsulationRange = GetInsulationStats(otherApparel);
 
-                        candidateRange.min -= otherInsulationRange.min;
-                        candidateRange.max -= otherInsulationRange.max;
+                            candidateRange.min -= otherInsulationRange.min;
+                            candidateRange.max -= otherInsulationRange.max;
+                        }
                     }
                 }
 

--- a/Source/OutfittedMod.cs
+++ b/Source/OutfittedMod.cs
@@ -136,7 +136,7 @@ namespace Outfitted
                 // system to solve would be fairly massive, optimizing for dozens of pawns and hundreds of pieces 
                 // of gear simultaneously. Second, many of the stat functions aren't actually linear, and would
                 // have to be made to be linear.
-                var currentlyWorn = pawn.apparel.WornApparel.Contains(apparel);
+                bool currentlyWorn = pawn.apparel.WornApparel.Contains(apparel);
 
                 var currentRange = pawn.ComfortableTemperatureRange();
                 var candidateRange = currentRange;


### PR DESCRIPTION
if a pawn is wearing low hp apparel and there is an otherwise identical item available that is new, the existing code favors greatly the currently worn item from the insulation method. I updated this to still include the worn item when calculating.