### PR TITLE
Fixes compatibility with Animal Genetics by respecting the "alwaysHidden" flag

### DIFF
--- a/Source/Patches/Dialog_ManageOutfits_Patch.cs
+++ b/Source/Patches/Dialog_ManageOutfits_Patch.cs
@@ -208,7 +208,7 @@ namespace Outfitted
             if (Widgets.ButtonImage(addStatRect, ResourceBank.Textures.AddButton))
             {
                 var options = new List<FloatMenuOption>();
-                foreach (var def in selectedOutfit.UnassignedStats.OrderBy(i => i.label).OrderBy(i => i.category.displayOrder))
+                foreach (var def in selectedOutfit.UnassignedStats.Where(i => !i.alwaysHide).OrderBy(i => i.label).OrderBy(i => i.category.displayOrder))
                 {
                     FloatMenuOption option = new FloatMenuOption(def.LabelCap, delegate
                     {


### PR DESCRIPTION
Animal Genetics uses mostly-empty StatDefs which lack labels and categories. This change makes it so the `alwaysHide` flag is respected when displaying the stats window, bypassing a null reference exception at `i.category.displayOrder`