### PR TITLE
Adding support for Save Storage Settings

### DIFF
--- a/Source/Patches/Dialog_ManageOutfits_Patch.cs
+++ b/Source/Patches/Dialog_ManageOutfits_Patch.cs
@@ -37,11 +37,17 @@ namespace Outfitted
                 return;
             }
 
+            float topAreaHeight = Dialog_ManageOutfits.TopAreaHeight + marginTop;
+            if (IsSaveStorageSettingsEnabled)
+            {
+                topAreaHeight += 40;
+            }
+
             Rect canvas = new Rect(
                 marginLeft,
-                Dialog_ManageOutfits.TopAreaHeight + marginTop,
+                topAreaHeight,
                 inRect.xMax - marginLeft - marginRight,
-                inRect.yMax - Dialog_ManageOutfits.TopAreaHeight - marginTop - marginBottom
+                inRect.yMax - topAreaHeight - marginTop - marginBottom
             );
 
             GUI.BeginGroup(canvas);
@@ -380,5 +386,20 @@ namespace Outfitted
 
             return Color.cyan;
         }
+
+        #region Determine whether save storage settings mod is enabled
+        private static bool? isSaveStorageSettingsEnabled = null;
+        internal static bool IsSaveStorageSettingsEnabled
+        {
+            get
+            {
+                if (isSaveStorageSettingsEnabled == null)
+                {
+                    isSaveStorageSettingsEnabled = new bool?(ModLister.GetActiveModWithIdentifier("savestoragesettings.kv.rw") != null);
+                }
+                return isSaveStorageSettingsEnabled.Value;
+            }
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
Adding support for Save Storage Settings. Basically moving the start of the buttons on the right side of the outfit assignment window down some so the Save/Load Outfit buttons can fit in there.

Save Storage Settings mod - https://steamcommunity.com/sharedfiles/filedetails/?id=1180718516

Thank you